### PR TITLE
Feature/response

### DIFF
--- a/src/main/java/csnojam/app/common/exception/ApiException.java
+++ b/src/main/java/csnojam/app/common/exception/ApiException.java
@@ -1,0 +1,11 @@
+package csnojam.app.common.exception;
+
+import csnojam.app.common.response.StatusMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiException extends RuntimeException {
+    private final StatusMessage statusMessage;
+}

--- a/src/main/java/csnojam/app/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/csnojam/app/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package csnojam.app.common.exception;
+
+import csnojam.app.common.response.ApiResponse;
+import csnojam.app.common.response.StatusMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<?>> handleApiException(ApiException e) {
+        StatusMessage statusMessage = e.getStatusMessage();
+        log.error(String.format("ApiException: %s - %d", statusMessage.getMessage(), statusMessage.getHttpStatus().value()));
+        return ApiResponse.withNothing(e.getStatusMessage());
+    }
+}

--- a/src/main/java/csnojam/app/common/response/ApiResponse.java
+++ b/src/main/java/csnojam/app/common/response/ApiResponse.java
@@ -1,0 +1,34 @@
+package csnojam.app.common.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class ApiResponse<T> {
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final T data;
+
+    private ApiResponse(StatusMessage statusMessage, T data) {
+        this.httpStatus = statusMessage.getHttpStatus();
+        this.message = statusMessage.getMessage();
+        this.data = data;
+    }
+
+    public static ResponseEntity<ApiResponse<?>> withNothing(StatusMessage statusMessage) {
+        ApiResponse<Object> apiResponse = new ApiResponse<>(statusMessage, null);
+        return new ResponseEntity<>(apiResponse, apiResponse.httpStatus);
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> withBody(StatusMessage statusMessage, T data) {
+        ApiResponse<T> apiResponse = new ApiResponse<>(statusMessage, data);
+        return new ResponseEntity<>(apiResponse, apiResponse.httpStatus);
+    }
+}

--- a/src/main/java/csnojam/app/common/response/StatusMessage.java
+++ b/src/main/java/csnojam/app/common/response/StatusMessage.java
@@ -1,0 +1,17 @@
+package csnojam.app.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StatusMessage {
+    // 200 OK
+    SUCCESS(HttpStatus.OK, "요청을 성공적으로 처리했습니다"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
- [x] 상태 메세지를 관리하는 StatusMessage enum 클래스 생성
- [x] Api 반환값을 생성하는 ApiResponse 클래스 생성
- [x] 로직 상의 exception을 발생시키기 위한 ApiException 클래스 생성
- [x] AOP로 exception을 처리하는 GlobalExeptionHandler 생성

### Response 예시
- 데이터가 없는 경우: `ApiResponse.withNothing(StatusMessage.SUCCESS);`
- 데이터가 있는 경우: `ApiResponse.withBody(StatusMessage.SUCCESS, data);`
- 에러 발생 경우: `throw new ApiException(StatusMessage.FAIL);`