### PR TITLE
Feature/spring rest docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.8'
 	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	id 'com.epages.restdocs-api-spec' version '0.16.4'
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'csnojam-backend.project'
@@ -9,6 +14,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
+	asciidoctorExtensions
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -35,7 +41,6 @@ dependencies {
 	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-//	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
 
 
@@ -51,10 +56,51 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.4'
+
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
+	swaggerUI 'org.webjars:swagger-ui:4.1.3'
 }
 
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+openapi3 {
+    servers = [
+			{ url = 'http://localhost:8080' }
+    ]
+	title = 'CS No Jam API'
+	description = ''
+	version = "${project.version}"
+	format = 'yaml'
+
+	copy {
+		from "build/api-spec"
+		into "src/main/resources/static/docs/"
+	}
+}
+
+swaggerSources {
+	register('CSNoJamApiDocument').configure {
+		setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+	}
+}
+
+tasks.withType(GenerateSwaggerUI) {
+	dependsOn('openapi3')
+}
+
+tasks.register('copySwaggerUI', Copy) {
+	dependsOn('generateSwaggerUICSNoJamApiDocument')
+	def generateSwaggerTask = tasks.named('generateSwaggerUICSNoJamApiDocument', GenerateSwaggerUI).get()
+	from("${generateSwaggerTask.outputDir}")
+	into("${project.buildDir}/resources/main/static")
+}
+
+tasks.withType(BootJar) {
+	dependsOn('copySwaggerUI')
 }

--- a/src/test/java/csnojam/app/utils/ApiDocumentUtils.java
+++ b/src/test/java/csnojam/app/utils/ApiDocumentUtils.java
@@ -1,0 +1,22 @@
+package csnojam.app.utils;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+public interface ApiDocumentUtils {
+    static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                prettyPrint()
+        );
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(
+                prettyPrint()
+        );
+    }
+}


### PR DESCRIPTION
- [x] Spring Rest Docs로 adoc 파일을 생성하기 위한 설정
- [x] adoc 파일로 openapi 형식 파일을 생성하는 설정
- [x] openapi 형식의 파일을 Swagger UI로 보여주기 위한 설정

### [사용 방법]
**테스트 코드**
    ![documentationExample](https://user-images.githubusercontent.com/42956464/218727839-0bb14f88-34a1-44b5-a030-e3ac55b54ba3.png)

**보라색 코드**
1. get: `RestDocumentationRequestBuilders`의 메소드 사용
2. document: `MockMvcRestDocumentationWrapper.document` 사용
3. getDocumentRequest, getDocumentResponse: `ApiDocumentUtils`의 static 메소드로 구현되어있음
4. resource: `ResourceDocumentation.resource` 사용

**Swagger UI 화면**
    <img src="https://user-images.githubusercontent.com/42956464/218734746-7d295f5d-1dcf-4159-997e-f9374b5f157d.png" width=55%/>

##
### [실행 방법]
- **Swagger UI 생성**: 터미널에서 명령어 `.\gradlew bootJar` 입력
- **Swagger UI 화면 확인**: `build/swagger-ui-CSNoJamApiDocument/index.html` 열기
- **Swagger UI에서 API 실행**: 터미널에서 명령어 `.\gradlew bootRun` 입력
    or `build/libs/csnojam-backend-0.0.1-SNAPSHOT.jar` 실행
